### PR TITLE
Update incorrect info in twilio.mdx docs

### DIFF
--- a/apps/docs/pages/guides/auth/phone-login/twilio.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/twilio.mdx
@@ -94,7 +94,7 @@ You should now be able to see all three values you'll need to get started:
 
 ![All the credentials you'll need](/docs/img/guides/auth-twilio/6.png)
 
-Now go to the Auth > Providers page in the Supabase dashboard and select "Phone" from the Auth Providers list (https://supabase.com/dashboard/project/YOUR-PROJECT-REF/auth/providers).
+Now go to the Auth > Providers page in the Supabase dashboard and select "Phone" from the Auth Providers list (https://supabase.com/dashboard/project/_/auth/providers).
 
 You should see an option to enable Phone Signup:
 
@@ -112,7 +112,7 @@ Now the backend should be setup, we can proceed to add our client-side code!
 
 The SMS message sent to a phone containing an OTP code can be customized. This is useful if you need to mention a brand name or display a website address.
 
-Go to Auth > Providers page (under "Configuration") in the Supabase dashboard and select "Phone" from the Auth Providers list (https://supabase.com/dashboard/project/YOUR-PROJECT-REF/auth/providers). Scroll to the very bottom of the "Phone" collapsible to the "SMS Message" input - you can customize the SMS message here.
+Go to Auth > Providers page (under "Configuration") in the Supabase dashboard and select "Phone" from the Auth Providers list (https://supabase.com/dashboard/project/_/auth/providers). Scroll to the very bottom of the "Phone" section to the "SMS Message" input - you can customize the SMS message here.
 
 Use the variable `.Code` in the template to display the OTP code. Here's an example in the SMS template.
 

--- a/apps/docs/pages/guides/auth/phone-login/twilio.mdx
+++ b/apps/docs/pages/guides/auth/phone-login/twilio.mdx
@@ -94,7 +94,7 @@ You should now be able to see all three values you'll need to get started:
 
 ![All the credentials you'll need](/docs/img/guides/auth-twilio/6.png)
 
-Now go to the Auth > Settings page in the Supabase dashboard (https://supabase.com/dashboard/project/YOUR-PROJECT-REF/auth/settings).
+Now go to the Auth > Providers page in the Supabase dashboard and select "Phone" from the Auth Providers list (https://supabase.com/dashboard/project/YOUR-PROJECT-REF/auth/providers).
 
 You should see an option to enable Phone Signup:
 
@@ -112,7 +112,7 @@ Now the backend should be setup, we can proceed to add our client-side code!
 
 The SMS message sent to a phone containing an OTP code can be customized. This is useful if you need to mention a brand name or display a website address.
 
-Go to Auth > Templates page in the Supabase dashboard (https://supabase.com/dashboard/project/YOUR-PROJECT-REF/auth/templates).
+Go to Auth > Providers page (under "Configuration") in the Supabase dashboard and select "Phone" from the Auth Providers list (https://supabase.com/dashboard/project/YOUR-PROJECT-REF/auth/providers). Scroll to the very bottom of the "Phone" collapsible to the "SMS Message" input - you can customize the SMS message here.
 
 Use the variable `.Code` in the template to display the OTP code. Here's an example in the SMS template.
 


### PR DESCRIPTION
It appears to be that the links/routes for Phone Auth have been updated within the Supabase dashboard but those changes are not reflected in the Supabase documentation. 

Not fixing this issue promptly could lead to confusion and frustration among users who rely on the documentation to set up Phone Auth for their project(s) + might result in users spending unnecessary time trying to locate the correct settings/page, potentially leading to abandonment of the Phone Auth integration or, worse, incorrect configuration attempts.

This link no longer takes users to the correct location: https://supabase.com/dashboard/project/YOUR-PROJECT-REF/auth/settings

This link does take users to the correct location: https://supabase.com/dashboard/project/YOUR-PROJECT-REF/auth/providers